### PR TITLE
chore(deploy): add railway.toml for server build config

### DIFF
--- a/server/railway.toml
+++ b/server/railway.toml
@@ -1,0 +1,6 @@
+[build]
+buildCommand = "npm install"
+
+[deploy]
+startCommand = "node src/app.js"
+healthcheckPath = "/api/health"


### PR DESCRIPTION
Adds `server/railway.toml` to explicitly configure Railway build and start commands.

Fixes the Railpack detection issue where the root `package.json` (workspace tooling only) was used instead of `server/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)