### PR TITLE
fix(server): surface startup error with console.error before process.exit

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -151,7 +151,7 @@ const startServer = async () => {
       info(`Server is running in ${NODE_ENV} mode on port ${PORT}`);
     });
   } catch (error) {
-    _error("Unable to start server:", error);
+    console.error("Unable to start server:", error);
     process.exit(1);
   }
 };


### PR DESCRIPTION
Winston's async transport is killed before flushing when `process.exit(1)` is called. The actual DB connection error was silently swallowed, causing Railway to see a crash loop with no useful logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)