### PR TITLE
fix(ui): adapt modals and status messages to dark theme

### DIFF
--- a/client/src/components/ModalActions.tsx
+++ b/client/src/components/ModalActions.tsx
@@ -35,7 +35,7 @@ const ModalActions: React.FC<ModalActionsProps> = ({
     : "bg-blue-600 hover:bg-blue-700 text-white";
 
   return (
-    <div className="px-6 py-4 bg-gray-50 flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-3 space-y-3 space-y-reverse sm:space-y-0">
+    <div className="px-6 py-4 bg-surface-1 flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-3 space-y-3 space-y-reverse sm:space-y-0">
       {/* Bouton Annuler */}
       <button
         type="button"

--- a/client/src/components/StatusMessage.tsx
+++ b/client/src/components/StatusMessage.tsx
@@ -19,13 +19,13 @@ const StatusMessage: React.FC<StatusMessageProps> = ({ type, message, id }) => {
   const getColors = () => {
     switch (type) {
       case "success":
-        return "text-green-800 bg-green-100 border-green-300";
+        return "text-green-200 bg-green-900/60 border-green-700";
       case "error":
-        return "text-red-800 bg-red-100 border-red-300";
+        return "text-red-200 bg-red-900/60 border-red-700";
       case "warning":
-        return "text-yellow-800 bg-yellow-100 border-yellow-300";
+        return "text-yellow-200 bg-yellow-900/60 border-yellow-700";
       case "info":
-        return "text-blue-800 bg-blue-100 border-blue-300";
+        return "text-blue-200 bg-blue-900/60 border-blue-700";
       default:
         return "text-text bg-primary/20 border-primary";
     }

--- a/client/src/utils/modalStyles.ts
+++ b/client/src/utils/modalStyles.ts
@@ -51,7 +51,7 @@ export const ModalStylesService = {
   getBaseModalClasses(size: ModalSize): string {
     return `
       relative mx-auto my-8 w-full ${ModalStylesService.getSizeClasses(size)}
-      bg-white rounded-lg shadow-xl transform transition-all
+      bg-surface-2 rounded-lg shadow-xl transform transition-all
       max-h-[90vh] overflow-hidden
     `
       .trim()
@@ -60,7 +60,7 @@ export const ModalStylesService = {
 
   getOverlayClasses(): string {
     return `
-      fixed inset-0 bg-black bg-opacity-50
+      fixed inset-0 bg-black/60 backdrop-blur-sm
       flex items-center justify-center p-4 z-50
       transition-opacity duration-200
     `


### PR DESCRIPTION
## Summary
- Replace `bg-white` and `bg-gray-50` with dark surface tokens (`bg-surface-2`, `bg-surface-1`) on modals
- Update `StatusMessage` colors from light backgrounds to dark variants for readability
- Add `backdrop-blur-sm` to modal overlay for better visual separation

## Test plan
- [ ] Open a confirmation modal (e.g. logout) and verify dark background with readable text
- [ ] Trigger status messages (success, error, warning, info) and verify colors
- [ ] Check modal overlay blur effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)