### PR TITLE
fix(cart): fix add-to-cart 500 error on Neon/Railway production

### DIFF
--- a/server/src/interfaces/ICartRepository.js
+++ b/server/src/interfaces/ICartRepository.js
@@ -7,7 +7,7 @@
  * Définit les méthodes que toute implémentation doit fournir
  */
 class ICartRepository {
-  async findByUserId(_userId) {
+  async findByUserId(_userId, _transaction) {
     throw new Error("Method findByUserId() must be implemented");
   }
 

--- a/server/src/models/index.js
+++ b/server/src/models/index.js
@@ -15,6 +15,15 @@ const sequelize = process.env.DATABASE_URL
       dialectOptions: {
         ssl: { require: true, rejectUnauthorized: false },
       },
+      pool: {
+        min: 0,
+        max: 10,
+        acquire: 30000,
+        idle: 10000,
+      },
+      retry: {
+        max: 3,
+      },
     })
   : new Sequelize({
       ...config,

--- a/server/src/repositories/SequelizeCartRepository.js
+++ b/server/src/repositories/SequelizeCartRepository.js
@@ -23,11 +23,11 @@ class SequelizeCartRepository extends ICartRepository {
    * @returns {Promise<Object|null>} Panier trouvé ou null
    * @throws {Error} Si la recherche échoue
    */
-  async findByUserId(userId) {
+  async findByUserId(userId, transaction = null) {
     try {
       validateId(userId, "User ID");
 
-      const cart = await this.Cart.findOne({
+      const options = {
         where: { userId },
         include: [
           {
@@ -41,7 +41,13 @@ class SequelizeCartRepository extends ICartRepository {
             ],
           },
         ],
-      });
+      };
+
+      if (transaction) {
+        options.transaction = transaction;
+      }
+
+      const cart = await this.Cart.findOne(options);
 
       return cart ? cart.toJSON() : null;
     } catch (error) {

--- a/server/src/services/CartService.js
+++ b/server/src/services/CartService.js
@@ -32,7 +32,7 @@ class CartService {
         throw new Error("User ID must be a valid number");
       }
 
-      let cart = await this.cartRepository.findByUserId(userId);
+      let cart = await this.cartRepository.findByUserId(userId, transaction);
 
       if (!cart) {
         cart = await this.cartRepository.create({ userId }, transaction);


### PR DESCRIPTION
## Summary
- Add connection pool (`min: 0, max: 10`) and retry config (`max: 3`) when using `DATABASE_URL` (Neon) to handle idle connection drops on serverless PostgreSQL
- Pass transaction to `findByUserId` in `getOrCreateCart` to prevent cross-connection deadlocks within the `addToCart` transaction
- Update `ICartRepository` interface to accept optional transaction parameter

## Root cause
When `DATABASE_URL` is set (Neon production), the Sequelize instance was created **without pool or retry config**, causing idle connections to be dropped by Neon's serverless PostgreSQL without reconnection. Additionally, `getOrCreateCart` opened a transaction but called `findByUserId` **outside** that transaction, using two separate pool connections — risking deadlocks on Neon's limited free-tier connections.

## Test plan
- [x] 76 server unit tests pass
- [x] 25 client tests pass
- [ ] Verify add-to-cart works in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)