### PR TITLE
fix(csrf): fix add-to-cart 403 in cross-origin production

### DIFF
--- a/server/src/middlewares/modernCsrf.js
+++ b/server/src/middlewares/modernCsrf.js
@@ -67,7 +67,7 @@ class ModernCSRF {
         res.cookie(this.cookieName, token, {
           httpOnly: false, // Accessible en JS pour headers
           secure: process.env.NODE_ENV === "production",
-          sameSite: process.env.NODE_ENV === "production" ? "strict" : "lax",
+          sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
           maxAge: this.maxAge * 1000,
         });
 


### PR DESCRIPTION
## Summary

- Fix CSRF cookie `sameSite` from `strict` to `none` in production, aligning with the session cookie config
- This was blocking all mutating requests (POST/PUT/DELETE) from the Vercel frontend to the Railway backend, including add-to-cart

## Root cause

The frontend (Vercel) and backend (Railway) are on different domains. The CSRF cookie was set with `sameSite=strict`, which prevents the browser from sending it on cross-origin requests. The `X-CSRF-Token` header was populated from the cookie on the client side, but since the cookie was never sent cross-site, the token was always missing → 403 error.

The session cookie already used `sameSite=none`, so the CSRF cookie was the only one misconfigured.

## Test plan

- [ ] Verify CI passes
- [ ] Deploy to Railway and confirm add-to-cart works from Vercel frontend
- [ ] Verify other mutating operations (update cart, remove from cart, checkout) also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)