### PR TITLE
fix(deploy): proxy API through Vercel to fix cookie blocking

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://stella-ecommerce-production.up.railway.app/api/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `vercel.json` with rewrites to proxy `/api/*` to Railway backend
- Fixes all authenticated requests (login, cart, wishlist, orders) failing in production

## Root cause

The frontend (stella-ecommerce.vercel.app) and backend (stella-ecommerce-production.up.railway.app) are on different domains. Modern browsers block **third-party cookies** by default. The `accessToken` and `XSRF-TOKEN` cookies set by Railway are never sent back by the browser because they're cross-site.

## Fix

Proxy API requests through Vercel rewrites so everything appears on the same domain:
- Browser → `stella-ecommerce.vercel.app/api/cart/add`
- Vercel proxy → `stella-ecommerce-production.up.railway.app/api/cart/add`

Cookies become first-party → no blocking.

## Required Vercel env change

Set `REACT_APP_API_URL` to `/api` (relative path) on Vercel, then redeploy.

## Test plan

- [ ] CI passes
- [ ] Set `REACT_APP_API_URL=/api` on Vercel
- [ ] Redeploy on Vercel
- [ ] Verify login works
- [ ] Verify add-to-cart works

🤖 Generated with [Claude Code](https://claude.com/claude-code)