### PR TITLE
fix(deploy): hardcode API proxy URL in .env.production

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=/api


### PR DESCRIPTION
## Summary

Adds `client/.env.production` with `REACT_APP_API_URL=/api` so CRA uses the Vercel proxy at build time, regardless of Vercel dashboard env var issues.

This ensures the frontend always routes API calls through the Vercel rewrite proxy (same domain = no third-party cookie blocking).

## Test plan

- [ ] Merge and verify Vercel triggers a new build
- [ ] Confirm login and add-to-cart work on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)