### PR TITLE
fix(ui): responsive layout fixes for 320px mobile

### DIFF
--- a/client/src/components/AccessibleSearchBox.tsx
+++ b/client/src/components/AccessibleSearchBox.tsx
@@ -101,7 +101,7 @@ const AccessibleSearchBox: React.FC<AccessibleSearchBoxProps> = ({
 
       {/* Panneau de recherche */}
       {isVisible && (
-        <div className="absolute right-0 top-full mt-2 w-80 bg-secondary border border-primary/20 rounded-lg shadow-lg p-4 z-50">
+        <div className="absolute right-0 top-full mt-2 w-[calc(100vw-2rem)] sm:w-80 bg-secondary border border-primary/20 rounded-lg shadow-lg p-4 z-50">
           {/* Champ de recherche */}
           <SearchInputField
             ref={searchInputRef}

--- a/client/src/components/CartStarCard.tsx
+++ b/client/src/components/CartStarCard.tsx
@@ -36,7 +36,7 @@ const CartStarCard: React.FC<CartStarCardProps> = ({
   return (
     <FadeInSection>
       <div className="bg-surface-1 text-text rounded-lg shadow-lg flex flex-row h-full mb-4 overflow-hidden border border-text/[0.07] transition-all duration-300 hover:border-text/20">
-        <picture className="w-1/4 flex-shrink-0">
+        <picture className="w-1/3 sm:w-1/4 flex-shrink-0">
           <source srcSet={getStarImagePathWebP(star)} type="image/webp" />
           <img
             src={getStarImagePath(star)}
@@ -51,7 +51,7 @@ const CartStarCard: React.FC<CartStarCardProps> = ({
           <h2 className="text-xl font-display mb-2 text-text">{star.name}</h2>
           <p className="text-sm mb-4">{star.description}</p>
 
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
             <span className="text-lg font-semibold">{star.price} €</span>
             {onUpdateQuantity ? (
               <div className="flex items-center gap-2">
@@ -59,7 +59,7 @@ const CartStarCard: React.FC<CartStarCardProps> = ({
                   type="button"
                   onClick={() => onUpdateQuantity(quantity - 1)}
                   disabled={quantity <= 1}
-                  className="w-11 h-11 rounded-md bg-primary text-text flex items-center justify-center disabled:opacity-30"
+                  className="w-9 h-9 sm:w-11 sm:h-11 rounded-md bg-primary text-text flex items-center justify-center disabled:opacity-30"
                   aria-label="Reduire la quantite"
                 >
                   -
@@ -68,7 +68,7 @@ const CartStarCard: React.FC<CartStarCardProps> = ({
                 <button
                   type="button"
                   onClick={() => onUpdateQuantity(quantity + 1)}
-                  className="w-11 h-11 rounded-md bg-primary text-text flex items-center justify-center"
+                  className="w-9 h-9 sm:w-11 sm:h-11 rounded-md bg-primary text-text flex items-center justify-center"
                   aria-label="Augmenter la quantite"
                 >
                   +

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 const Footer: React.FC = () => {
   return (
     <footer className="border-t border-text/[0.06] mt-20">
-      <div className="max-w-[1100px] mx-auto px-10 py-12">
+      <div className="max-w-[1100px] mx-auto px-4 sm:px-10 py-12">
         <div className="flex flex-col gap-6 sm:flex-row sm:justify-between sm:items-end">
           <div>
             <span className="font-display text-xl text-text/70">Stella</span>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -28,7 +28,7 @@ const Header: React.FC = () => {
 
   const headerClasses = [
     "fixed top-0 left-0 right-0 z-50",
-    "flex justify-between items-center px-6 md:px-10 lg:px-20 h-[52px]",
+    "flex justify-between items-center px-4 sm:px-6 md:px-10 lg:px-20 h-[52px]",
     "transition-all duration-300 ease-in-out",
     scrolled
       ? "bg-purple-950/88 backdrop-blur-xl border-b border-text/[0.06]"

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -80,7 +80,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, onToggle }) => {
 
       {/* Search panel */}
       {isVisible && (
-        <div className="absolute right-0 top-full mt-2 w-80 bg-secondary border border-primary/20 rounded-lg shadow-lg p-4 z-50">
+        <div className="absolute right-0 top-full mt-2 w-[calc(100vw-2rem)] sm:w-80 bg-secondary border border-primary/20 rounded-lg shadow-lg p-4 z-50">
           <form onSubmit={handleSubmit} className="relative">
             <input
               ref={(input) => {

--- a/client/src/components/WishlistStarCard.tsx
+++ b/client/src/components/WishlistStarCard.tsx
@@ -22,7 +22,7 @@ const WishlistStarCard: React.FC<WishlistStarCardProps> = ({ star, onRemove }) =
   return (
     <FadeInSection>
       <div className="bg-surface-1 text-text rounded-lg shadow-lg flex flex-row h-full mb-4 overflow-hidden border border-text/[0.07] transition-all duration-300 hover:border-text/20">
-        <picture className="w-1/4 flex-shrink-0">
+        <picture className="w-1/3 sm:w-1/4 flex-shrink-0">
           <source srcSet={getStarImagePathWebP(star)} type="image/webp" />
           <img
             src={getStarImagePath(star)}

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -144,10 +144,10 @@ const DashboardView: React.FC<{ data: DashboardData }> = ({ data }) => {
 
   return (
     <div className="space-y-8">
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         {stats.map((stat) => (
           <FadeInSection key={stat.label}>
-            <div className="bg-secondary text-text p-6 rounded-lg shadow-lg text-center">
+            <div className="bg-secondary text-text p-4 sm:p-6 rounded-lg shadow-lg text-center">
               <p className="text-2xl font-bold">{stat.value}</p>
               <p className="text-sm font-serif text-text/70">{stat.label}</p>
             </div>
@@ -188,25 +188,29 @@ const DashboardView: React.FC<{ data: DashboardData }> = ({ data }) => {
 const UsersView: React.FC<{ users: AdminUser[] }> = ({ users }) => {
   return (
     <FadeInSection>
-      <div className="bg-secondary text-text rounded-lg shadow-lg overflow-hidden">
-        <table className="w-full">
+      <div className="bg-secondary text-text rounded-lg shadow-lg overflow-x-auto">
+        <table className="w-full min-w-[500px]">
           <caption className="sr-only">Liste des utilisateurs inscrits</caption>
           <thead>
             <tr className="border-b border-primary/20">
-              <th className="text-left p-4 font-display">Nom</th>
-              <th className="text-left p-4 font-display">Email</th>
-              <th className="text-left p-4 font-display">Role</th>
-              <th className="text-left p-4 font-display">Inscription</th>
+              <th className="text-left p-3 sm:p-4 font-display">Nom</th>
+              <th className="text-left p-3 sm:p-4 font-display">Email</th>
+              <th className="text-left p-3 sm:p-4 font-display">Role</th>
+              <th className="text-left p-3 sm:p-4 font-display hidden sm:table-cell">
+                Inscription
+              </th>
             </tr>
           </thead>
           <tbody>
             {users.map((u) => (
               <tr key={u.id} className="border-b border-primary/10">
-                <td className="p-4 font-serif">
+                <td className="p-3 sm:p-4 font-serif">
                   {u.firstName} {u.lastName}
                 </td>
-                <td className="p-4 text-sm">{u.email}</td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-sm truncate max-w-[120px] sm:max-w-none">
+                  {u.email}
+                </td>
+                <td className="p-3 sm:p-4">
                   <span
                     className={`px-2 py-1 rounded-full text-xs ${
                       u.role === "admin"
@@ -217,7 +221,7 @@ const UsersView: React.FC<{ users: AdminUser[] }> = ({ users }) => {
                     {u.role}
                   </span>
                 </td>
-                <td className="p-4 text-sm text-text/70">
+                <td className="p-3 sm:p-4 text-sm text-text/70 hidden sm:table-cell">
                   {new Date(u.createdAt).toLocaleDateString("fr-FR")}
                 </td>
               </tr>

--- a/client/src/pages/Certificate.tsx
+++ b/client/src/pages/Certificate.tsx
@@ -118,7 +118,7 @@ const Certificate: React.FC = () => {
           <div className="absolute bottom-4 left-4 w-8 h-8 border-b-2 border-l-2 border-cyan-400/50" />
           <div className="absolute bottom-4 right-4 w-8 h-8 border-b-2 border-r-2 border-cyan-400/50" />
 
-          <div className="px-8 py-12 sm:px-16 sm:py-16 text-center">
+          <div className="px-4 py-8 sm:px-8 sm:py-12 md:px-16 md:py-16 text-center">
             {/* En-tête */}
             <div className="mb-8">
               <div className="text-cyan-400 text-sm tracking-[0.3em] uppercase mb-2 font-serif">

--- a/client/src/pages/Checkout.tsx
+++ b/client/src/pages/Checkout.tsx
@@ -101,7 +101,7 @@ const Checkout: React.FC = () => {
                     placeholder="123 Rue des Etoiles"
                     isRequired
                   />
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <FormInput
                       label="Ville"
                       name="city"
@@ -119,7 +119,7 @@ const Checkout: React.FC = () => {
                       isRequired
                     />
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <FormInput
                       label="Region"
                       name="state"

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -57,8 +57,8 @@ const Home: React.FC = () => {
 
       {/* Section Qui sommes-nous ? */}
       <FadeInSection>
-        <section className="max-w-[1100px] mx-auto text-text py-24 px-10">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-16 items-center">
+        <section className="max-w-[1100px] mx-auto text-text py-24 px-4 sm:px-10">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16 items-center">
             <div>
               <p className="text-[10px] uppercase tracking-[0.2em] text-special/60 mb-4 font-sans">
                 QUI SOMMES-NOUS
@@ -96,7 +96,7 @@ const Home: React.FC = () => {
       {/* Section Nouveautés */}
       <FadeInSection>
         <section className="pb-24 text-text">
-          <div className="max-w-[1100px] mx-auto px-10">
+          <div className="max-w-[1100px] mx-auto px-4 sm:px-10">
             <div className="flex items-baseline justify-between mb-10">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.2em] text-special/60 mb-2 font-sans">
@@ -144,7 +144,7 @@ const Home: React.FC = () => {
       {/* Afficher la section "Rejoignez-nous" seulement si l'utilisateur n'est pas connecté */}
       {!isAuthenticated && (
         <FadeInSection>
-          <section className="py-24 text-text text-center px-10">
+          <section className="py-24 text-text text-center px-4 sm:px-10">
             <h2 className="text-3xl md:text-[clamp(32px,5vw,64px)] font-display mb-4 text-periwinkle-100 tracking-tight leading-none">
               Rejoignez-nous
             </h2>


### PR DESCRIPTION
## Summary

Fixes responsive layout issues at 320px viewport width across multiple components and pages.

## Changes

### Critical fixes (overflow prevention)
- **SearchBar / AccessibleSearchBox**: Fixed `w-80` dropdown → `w-[calc(100vw-2rem)] sm:w-80`
- **Footer / Home**: `px-10` → `px-4 sm:px-10` (40px padding was eating 25% of viewport)

### Grid layout fixes
- **Checkout**: Address form `grid-cols-2` → `grid-cols-1 sm:grid-cols-2`
- **Admin**: Stats grid `grid-cols-2` → `grid-cols-1 sm:grid-cols-2 md:grid-cols-4`

### Component improvements
- **Header**: `px-6` → `px-4 sm:px-6` for tighter mobile
- **Certificate**: Progressive padding `px-4 sm:px-8 md:px-16`
- **CartStarCard / WishlistStarCard**: Image `w-1/4` → `w-1/3 sm:w-1/4`
- **Cart quantity buttons**: `w-11` → `w-9 sm:w-11`
- **Admin table**: `overflow-x-auto`, hidden date column on mobile, truncated emails

## Test plan

- [ ] Check all pages at 320px viewport in Chrome DevTools
- [ ] No horizontal scrollbar on any page
- [ ] Forms remain usable (inputs not too narrow)
- [ ] Cart items display correctly with quantity controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)